### PR TITLE
fix: switch assert to pure

### DIFF
--- a/src/assert_m.F90
+++ b/src/assert_m.F90
@@ -31,7 +31,7 @@ module assert_m
 
   interface
 
-    elemental module subroutine assert(assertion, description, diagnostic_data)
+    pure module subroutine assert(assertion, description, diagnostic_data)
       !! If assertion is .false., error-terminate with a character stop code that contains diagnostic_data if present
       implicit none
       logical, intent(in) :: assertion


### PR DESCRIPTION
Making assert elemental gives confusing output because only the
first element of array diagnost_data shows in the ouptut of a
failed assertion.  For printing array data as diagnostic output,
it is better for a user to package that data in an object and
pass a characterizable_t object as the actual diagnostic_data
argument.