### PR TITLE
fix(allocation warnings): intrinsic_array_s

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - uses: fortran-lang/setup-fpm@v3
+    - uses: fortran-lang/setup-fpm@v4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,11 +23,10 @@ jobs:
 
     - name: Build Developer Documenation
       run: |
-        cd doc
         # Turn warnings into errors
         ford doc-generator.md > ford_output.txt
         cat ford_output.txt; if grep -q -i Warning ford_output.txt; then exit 1; fi
-        cp ../README.md html
+        cp ./README.md ./doc/html
 
     - name: Upload Documentation
       uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,10 @@ jobs:
   Build:
     runs-on: ubuntu-22.04
 
+    env:
+      FC: gfortran
+      GCC_V: 12
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -14,12 +18,16 @@ jobs:
     - name: Install Dependencies Ubuntu
       run: |
         sudo apt-get update
-        sudo apt install -y python3-dev python3 build-essential graphviz gfortran-12
-        sudo pip install ford
+        sudo apt install -y gfortran-${GCC_V} python3-dev python3 build-essential numdiff graphviz
+        sudo pip install ford markdown==3.3.4
 
     - name: Build Developer Documenation
       run: |
-        ford doc-generator.md
+        cd doc
+        # Turn warnings into errors
+        ford doc-generator.md > ford_output.txt
+        cat ford_output.txt; if grep -q -i Warning ford_output.txt; then exit 1; fi
+        cp ../README.md html
 
     - name: Upload Documentation
       uses: actions/upload-artifact@v2

--- a/src/intrinsic_array_s.F90
+++ b/src/intrinsic_array_s.F90
@@ -11,15 +11,15 @@ contains
 #endif
       select type(array)
       type is(complex)
-        intrinsic_array%complex_1D = array
+        allocate(intrinsic_array%complex_1D, source = array)
       type is(integer)
-        intrinsic_array%integer_1D = array
+        allocate(intrinsic_array%integer_1D, source = array)
       type is(logical)
-        intrinsic_array%logical_1D = array
+        allocate(intrinsic_array%logical_1D, source = array)
       type is(real)
-        intrinsic_array%real_1D = array
+        allocate(intrinsic_array%real_1D, source = array)
       type is(double precision)
-        intrinsic_array%double_precision_1D = array
+        allocate(intrinsic_array%double_precision_1D, source = array)
       class default
         error  stop "intrinsic_array_t construct: unsupported rank-2 type"
       end select
@@ -27,15 +27,15 @@ contains
     rank(2)
       select type(array)
       type is(complex)
-        intrinsic_array%complex_2D = array
+        allocate(intrinsic_array%complex_2D, source = array)
       type is(integer)
-        intrinsic_array%integer_2D = array
+        allocate(intrinsic_array%integer_2D, source = array)
       type is(logical)
-        intrinsic_array%logical_2D = array
+        allocate(intrinsic_array%logical_2D, source = array)
       type is(real)
-        intrinsic_array%real_2D = array
+        allocate(intrinsic_array%real_2D, source = array)
       type is(double precision)
-        intrinsic_array%double_precision_2D = array
+        allocate(intrinsic_array%double_precision_2D, source = array)
       class default
         error  stop "intrinsic_array_t construct: unsupported rank-2 type"
       end select
@@ -43,15 +43,15 @@ contains
     rank(3)
       select type(array)
       type is(complex)
-        intrinsic_array%complex_3D = array
+        allocate(intrinsic_array%complex_3D, source = array)
       type is(integer)
-        intrinsic_array%integer_3D = array
+        allocate(intrinsic_array%integer_3D, source = array)
       type is(logical)
-        intrinsic_array%logical_3D = array
+        allocate(intrinsic_array%logical_3D, source = array)
       type is(real)
-        intrinsic_array%real_3D = array
+        allocate(intrinsic_array%real_3D, source = array)
       type is(double precision)
-        intrinsic_array%double_precision_3D = array
+        allocate(intrinsic_array%double_precision_3D, source = array)
       class default
         error  stop "intrinsic_array_t construct: unsupported rank-3 type"
       end select
@@ -62,11 +62,11 @@ contains
 #endif
 
   end procedure
-  
+
   module procedure as_character
     integer, parameter :: single_number_width=32
 
-    if (1 /= count( & 
+    if (1 /= count( &
       [ allocated(self%complex_1D), allocated(self%complex_double_1D), allocated(self%integer_1D), &
         allocated(self%logical_1D), allocated(self%real_1D), &
         allocated(self%complex_2D), allocated(self%complex_double_2D), allocated(self%integer_2D), &
@@ -132,6 +132,6 @@ contains
     end if
 
     character_self = trim(adjustl(character_self))
-  end procedure 
+  end procedure
 
 end submodule intrinsic_array_s


### PR DESCRIPTION
When compiling with gfortran-12, the `[-Wmaybe-uninitialized]` warning is triggered by direct assignment instead of using an `allocate` statement.  This PR fixes these warnings.