### PR TITLE
feat(build): support flang-new

### DIFF
--- a/src/assert/assert_subroutine_s.F90
+++ b/src/assert/assert_subroutine_s.F90
@@ -20,9 +20,13 @@ contains
       check_assertion: &
       if (.not. assertion) then
 
+#ifndef __flang__
         associate(me=>this_image()) ! work around gfortran bug
           header = 'Assertion "' // description // '" failed on image ' // string(me)
         end associate
+#else
+          header = 'Assertion "' // description // '" failed.'
+#endif
  
         represent_diagnostics_as_string: &
         if (.not. present(diagnostic_data)) then

--- a/test/unit-tests/designed-to-error-terminate.F90
+++ b/test/unit-tests/designed-to-error-terminate.F90
@@ -16,9 +16,11 @@ program designed_to_error_terminate
 
     error_termination = exit_status /=0
 
+#ifndef __flang__
     call co_all(error_termination)
 
     if (this_image()==1) then
+#endif
 
       if (error_termination) then
         print *, "----> All tests designed to error-terminate pass.    <----"
@@ -26,7 +28,9 @@ program designed_to_error_terminate
         print *, "----> One or more tests designed to error-terminate terminated normally. Yikes! Who designed this OS? <----"
       end if
 
+#ifndef __flang__
     end if
+#endif
 
   end block
 
@@ -40,11 +44,13 @@ contains
 
   end function
 
+#ifndef __flang__
   subroutine co_all(boolean)
     logical, intent(inout) :: boolean
 
     call co_reduce(boolean, and_operation)
 
   end subroutine
+#endif
 
 end program

--- a/test/unit-tests/designed-to-terminate-normally.f90
+++ b/test/unit-tests/designed-to-terminate-normally.f90
@@ -33,8 +33,11 @@ program designed_to_terminate_normally
 
   end block array_diagnostic_data
 
+#ifndef __flang__
   sync all
 
-  if (this_image()==1) print *, "----> All tests designed to terminate normally pass. <----"
+  if (this_image()==1) &
+#endif
+   print *, "----> All tests designed to terminate normally pass. <----"
 
 end program designed_to_terminate_normally


### PR DESCRIPTION
This commit uses LLVM flang's predefined macro to eliminate native Fortran parallel features `this_image()` and `sync all` when building with flang-new.