### PR TITLE
Macro docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,4 +30,4 @@ jobs:
 
     - name: Build and Test
       run: |
-        fpm test
+        fpm test --profile release --flag -ffree-line-length-0

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ The `characterizable_t` type defines an `as_character()` deferred binding that p
 
 The `intrinsic_array_t` type that extends `characterizable_t` provides a convenient mechanism for producing diagnostic output from arrays of intrinsic type `complex`, `integer`, `logical`, or `real`.
 
-Documentation
--------------
-See [Assert's GitHub Pages site] for HTML documentation generated with [`ford`].
-
 Use Cases
 ---------
 Two common use cases include
@@ -117,6 +113,9 @@ See the [./example](./example) subdirectory.
 
 Documentation
 -------------
+
+See [Assert's GitHub Pages site] for HTML documentation generated with [`ford`].
+
 For further documentation, please see [example/README.md] and the [tests].  Also, the code in [src] has comments formatted for generating HTML documentation using [FORD].
 
 [Hyperlinks]:#

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ limit. This can result in compile-time errors like the following from gfortran:
 Error: Line truncated at (1) [-Werror=line-truncation]
 ```
 
-Some compilers offer a command-line argument that can be used to workaround this annoying limit, eg:
+Some compilers offer a command-line argument that can be used to workaround this legacy limit, eg:
 
 * `gfortran -ffree-line-length-0` aka `gfortran -ffree-line-length-none`
 
@@ -180,7 +180,7 @@ Instead when breaking long lines in a macro invocation, just break the line (no
 continuation character!), eg:
 
 ```fortran
-! When breaking a lines in a macro invocation, just use new-line!
+! When breaking a lines in a macro invocation, just use new-line with no `&` continuation character:
 call_assert_diagnose( computed_checksum == expected_checksum,
                       "Checksum mismatch failure!",
                       expected_checksum )                  
@@ -188,7 +188,7 @@ call_assert_diagnose( computed_checksum == expected_checksum,
 
 #### Comments in macro invocations
 
-The Fortran language sadly does not support comments with an end delimiter,
+Fortran does not support comments with an end delimiter,
 only to-end-of-line comments.  As such, there is no way to safely insert a
 Fortran comment into the middle of a macro invocation.  For example, the
 following seemingly reasonable code results in a syntax error

--- a/test/test-assert-macro.F90
+++ b/test/test-assert-macro.F90
@@ -38,6 +38,21 @@ program test_assert_macros
   call_assert_diagnose(.true., ".true.", diagnostic_data=1)
   print *,"  passes on not error-terminating when assertion = .true. and description and diagnostic_data are present"
 
+  block
+  integer :: computed_checksum = 37, expected_checksum = 37
+
+  call_assert_diagnose( computed_checksum == expected_checksum,
+                      "Checksum mismatch failure!",
+                      expected_checksum )     
+  print *,"  passes with macro-style line breaks"
+
+  call_assert_diagnose( computed_checksum == expected_checksum, /* ensured since version 3.14 */
+                        "Checksum mismatch failure!",           /* TODO: write a better message here */
+                        computed_checksum )
+  print *,"  passes with C block comments embedded in macro"
+
+  end block
+
 #undef DEBUG
 #include "assert_macros.h"
   call_assert_describe(.false., "")


### PR DESCRIPTION
Adds documentation about macro pitfalls, and a few tests of the documented resolutions.

These new tests also required adding the documented `fpm --flag -ffree-line-length-0` workaround to bypass the 132 character default line limit enforced by gfortran-12. This could alternatively be resolved by upgrading CI to gfortran 14.1 or later.