### PR TITLE
Update CPP_STRINGIFY_SOURCE for LFortran

### DIFF
--- a/include/assert_macros.h
+++ b/include/assert_macros.h
@@ -13,7 +13,8 @@
 ! Deal with stringification issues:
 ! https://gcc.gnu.org/legacy-ml/fortran/2009-06/msg00131.html
 #ifndef CPP_STRINGIFY_SOURCE
-# if defined(__GFORTRAN__) || defined(_CRAYFTN) || defined(NAGFOR) || defined(__LFORTRAN__)
+# if defined(__GFORTRAN__) || defined(_CRAYFTN) || defined(NAGFOR) || \
+    (defined(__LFORTRAN__) && __LFORTRAN_MAJOR__ == 0 && __LFORTRAN_MINOR__ < 60)
 #  define CPP_STRINGIFY_SOURCE(x) "x"
 # else
 #  define CPP_STRINGIFY_SOURCE(x) #x


### PR DESCRIPTION
LFortran 0.60 added preprocessor support for the CPP-style stringification operator (#), so use it.